### PR TITLE
Blur frame when user out of frame

### DIFF
--- a/Source/UserLocServer/Private/HeadTracking.cpp
+++ b/Source/UserLocServer/Private/HeadTracking.cpp
@@ -55,7 +55,7 @@ void UHeadTracking::TickComponent(float DeltaTime, ELevelTick TickType, FActorCo
 /*
 * Updates head position based on the UDP component data.
 */
-void UHeadTracking::GetFaceCoordinates(FVector& newLocation)
+bool UHeadTracking::GetFaceCoordinates(FVector& newLocation)
 {
     FString Data = "";
 
@@ -64,7 +64,7 @@ void UHeadTracking::GetFaceCoordinates(FVector& newLocation)
         // Data should be have retrived, but if not the tracking component does nothing 
         if (Data.IsEmpty())
         {
-            return;
+            return false;
         }
 
         // Assuming the data format is: '(X,Y,Z)' 
@@ -97,8 +97,11 @@ void UHeadTracking::GetFaceCoordinates(FVector& newLocation)
                 Z = ZAxis ? CalculateAverage(ZList) : Z;
             }
             newLocation = FVector(X, Y, Z);
+            return true; 
         } 
     }
+
+    return false; 
 }
 
 /*

--- a/Source/UserLocServer/Private/MovableCamera.cpp
+++ b/Source/UserLocServer/Private/MovableCamera.cpp
@@ -271,8 +271,8 @@ bool AMovableCamera::AddDebugMessageIfUserOutOfView(bool has_coords) {
     else {
         // A frame with the user 
         // Reset all varaibles and remove any debug messages 
-        bHasDebugMessage = false; 
-        GEngine->ClearOnScreenDebugMessages();
+        if (bHasDebugMessage) GEngine->ClearOnScreenDebugMessages();
+        bHasDebugMessage = false;
         BlurCounter = 0; 
     }
     return false; 

--- a/Source/UserLocServer/Private/MovableCamera.cpp
+++ b/Source/UserLocServer/Private/MovableCamera.cpp
@@ -145,29 +145,10 @@ void AMovableCamera::UpdatePosition()
 
     // Gets the face coordinates from the headtracking component.
     bool bDidGetCoords = HeadTrackingComponent->GetFaceCoordinates(newLocation);
-    
 
-    if (!bDidGetCoords){
-        if (BlurCounter > 5) {
-            UE_LOG(LogTemp, Warning, TEXT("BLUR"));
-            if (!bHasDebugMessage) {
-                CameraComponent->SetFieldOfView(0); 
-                FString message = FString("Please move in the field of view");
-                GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::White, message, true, FVector2D(2.0f));
-                bHasDebugMessage = true;
-            }
-            return; 
-            
-        }
-        GEngine->ClearOnScreenDebugMessages();
-        BlurCounter += 1;
-    }
-    else {
-        bHasDebugMessage = false; 
-        GEngine->ClearOnScreenDebugMessages();
-        BlurCounter -= 1; 
-        BlurCounter = fmax(0, BlurCounter); 
-    }
+    // Check if we need to tell the user if they are out of view by blocking the main thread of the program  
+    if (AddDebugMessageIfUserOutOfView(bDidGetCoords)) return; // No need to update the postion. Exit the function
+
 
     UE_LOG(LogTemp, Warning, TEXT("NEW LOCATION: %f %f %f"), newLocation.X, newLocation.Y, newLocation.Z);
 
@@ -260,3 +241,39 @@ void AMovableCamera::LoadPresetsFromDataTable()
         }
     }
 }
+
+/*
+    Function for printing a message to the user is out of view of the camera.
+    Will set the field of view to zero and add the message to the screen telling the user to move back into frame. 
+
+    Returns true if the user is out of view 
+*/
+bool AMovableCamera::AddDebugMessageIfUserOutOfView(bool has_coords) {
+    if (!has_coords){
+        // Has to go at least 5 ticks without seing the user in a row. 
+        if (BlurCounter > 5) {
+            // Prints the debug message to the screen
+            if (!bHasDebugMessage) {
+                CameraComponent->SetFieldOfView(0); 
+                FString message = FString("\nYou are out of view from the camera, or OpenCV server is not running.\nPlease move in the field of view of the camera...");
+                GEngine->AddOnScreenDebugMessage(-1, 20.0f, FColor::White, message, true, FVector2D(2.5f));
+                bHasDebugMessage = true;
+            }
+            return true; 
+            
+        }
+        // Clear message form the screen
+        GEngine->ClearOnScreenDebugMessages();
+
+        // Increment the amount of frames the user was out of view. 
+        BlurCounter += 1;
+    }
+    else {
+        // A frame with the user 
+        // Reset all varaibles and remove any debug messages 
+        bHasDebugMessage = false; 
+        GEngine->ClearOnScreenDebugMessages();
+        BlurCounter = 0; 
+    }
+    return false; 
+};

--- a/Source/UserLocServer/Private/MovableCamera.cpp
+++ b/Source/UserLocServer/Private/MovableCamera.cpp
@@ -137,8 +137,18 @@ void AMovableCamera::UpdatePosition()
     FVector LastKnownPosition = StartLocation;
     FRotator LastKnownRotation = StartDirection;
 
+    FVector LastLocation = FVector(newLocation.X, newLocation.Y, newLocation.Z);
+
     // Gets the face coordinates from the headtracking component.
     HeadTrackingComponent->GetFaceCoordinates(newLocation);
+
+    float BLUR_THRESHOLD = 0.001; 
+    if (abs(newLocation.X - LastLocation.X) < BLUR_THRESHOLD && abs(newLocation.Y - LastLocation.Y) < BLUR_THRESHOLD && abs(newLocation.Z - LastLocation.Z) < BLUR_THRESHOLD) {
+        UE_LOG(LogTemp, Warning, TEXT("BLUR"));
+        return;
+    }
+
+    UE_LOG(LogTemp, Warning, TEXT("NEW LOCATION: %f %f %f"), newLocation.X, newLocation.Y, newLocation.Z);
 
     // New position of the camera after handling as FVector, the standard format of coordinates.
     if (IncludeMovement)

--- a/Source/UserLocServer/Private/MovableCamera.cpp
+++ b/Source/UserLocServer/Private/MovableCamera.cpp
@@ -35,6 +35,9 @@ AMovableCamera::AMovableCamera()
     Scalar_X = (WidthUE / 480.0f) * XMovementSensitivity;
     Scalar_Y = (HeightUE / 480.0f) * YMovementSensitivity;
 
+
+    BlurCounter = 0;
+
     // Initilize the new location as a vector 
     newLocation = FVector();
 }
@@ -140,12 +143,19 @@ void AMovableCamera::UpdatePosition()
     FVector LastLocation = FVector(newLocation.X, newLocation.Y, newLocation.Z);
 
     // Gets the face coordinates from the headtracking component.
-    HeadTrackingComponent->GetFaceCoordinates(newLocation);
+    bool bDidGetCoords = HeadTrackingComponent->GetFaceCoordinates(newLocation);
 
-    float BLUR_THRESHOLD = 0.001; 
-    if (abs(newLocation.X - LastLocation.X) < BLUR_THRESHOLD && abs(newLocation.Y - LastLocation.Y) < BLUR_THRESHOLD && abs(newLocation.Z - LastLocation.Z) < BLUR_THRESHOLD) {
-        UE_LOG(LogTemp, Warning, TEXT("BLUR"));
-        return;
+    if (!bDidGetCoords){
+        if (BlurCounter > 5) {
+            UE_LOG(LogTemp, Warning, TEXT("BLUR"));
+            CameraComponent->SetFieldOfView(0); 
+            return;
+        }
+        BlurCounter += 1;
+    }
+    else {
+        BlurCounter -= 1; 
+        BlurCounter = fmax(0, BlurCounter); 
     }
 
     UE_LOG(LogTemp, Warning, TEXT("NEW LOCATION: %f %f %f"), newLocation.X, newLocation.Y, newLocation.Z);

--- a/Source/UserLocServer/Private/MovableCamera.cpp
+++ b/Source/UserLocServer/Private/MovableCamera.cpp
@@ -37,6 +37,7 @@ AMovableCamera::AMovableCamera()
 
 
     BlurCounter = 0;
+    bHasDebugMessage = false; 
 
     // Initilize the new location as a vector 
     newLocation = FVector();
@@ -144,16 +145,26 @@ void AMovableCamera::UpdatePosition()
 
     // Gets the face coordinates from the headtracking component.
     bool bDidGetCoords = HeadTrackingComponent->GetFaceCoordinates(newLocation);
+    
 
     if (!bDidGetCoords){
         if (BlurCounter > 5) {
             UE_LOG(LogTemp, Warning, TEXT("BLUR"));
-            CameraComponent->SetFieldOfView(0); 
-            return;
+            if (!bHasDebugMessage) {
+                CameraComponent->SetFieldOfView(0); 
+                FString message = FString("Please move in the field of view");
+                GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::White, message, true, FVector2D(2.0f));
+                bHasDebugMessage = true;
+            }
+            return; 
+            
         }
+        GEngine->ClearOnScreenDebugMessages();
         BlurCounter += 1;
     }
     else {
+        bHasDebugMessage = false; 
+        GEngine->ClearOnScreenDebugMessages();
         BlurCounter -= 1; 
         BlurCounter = fmax(0, BlurCounter); 
     }

--- a/Source/UserLocServer/Public/HeadTracking.h
+++ b/Source/UserLocServer/Public/HeadTracking.h
@@ -33,7 +33,7 @@ public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Networking")
         UUDPReceiver* UDPReceiverComponent;
 
-    void GetFaceCoordinates(FVector&);
+    bool GetFaceCoordinates(FVector&);
 
     // Use smoothing or not when tracking head.
     UPROPERTY(EditAnywhere, Category = "Head Tracking (Server)")

--- a/Source/UserLocServer/Public/MovableCamera.h
+++ b/Source/UserLocServer/Public/MovableCamera.h
@@ -141,6 +141,9 @@ private:
     float BlurCounter; 
     bool bHasDebugMessage; 
 
+    // Function for telling the user that they are out of view 
+    bool AddDebugMessageIfUserOutOfView(bool has_coords); 
+
     // Function for updating the user postion 
     void UpdatePosition();
 

--- a/Source/UserLocServer/Public/MovableCamera.h
+++ b/Source/UserLocServer/Public/MovableCamera.h
@@ -139,6 +139,7 @@ private:
     float CY;
 
     float BlurCounter; 
+    bool bHasDebugMessage; 
 
     // Function for updating the user postion 
     void UpdatePosition();

--- a/Source/UserLocServer/Public/MovableCamera.h
+++ b/Source/UserLocServer/Public/MovableCamera.h
@@ -138,6 +138,8 @@ private:
     float CX;
     float CY;
 
+    float BlurCounter; 
+
     // Function for updating the user postion 
     void UpdatePosition();
 


### PR DESCRIPTION
# What?

This feature will tell the user if they are out of frame. 

The first screenshot shows what the user sees when the user has the camera running correctly and are in the field of view

![image](https://github.com/RIT-NTNU-Bachelor/Unreal-facetracking-client/assets/66110094/f76b7ab5-2743-40c6-85e6-9986dbc03809)

This is what the user sees when we is out of frame or the OpenCV server is not running.
![image](https://github.com/RIT-NTNU-Bachelor/Unreal-facetracking-client/assets/66110094/aebde836-6893-49ac-a9a9-3be049903f04)

